### PR TITLE
3.4.1 redux lldp

### DIFF
--- a/roles/server-common/tasks/main.yaml
+++ b/roles/server-common/tasks/main.yaml
@@ -43,19 +43,27 @@
 - apt:
     update_cache: yes
   become: true
-      
+
 
 - name: install useful operational packages
   apt:
     name: "{{ item }}"
   become: true
-  with_items: 
+  with_items:
   - zile
   - lldpd
   - traceroute
   - ifupdown
   - tcpdump
   - ethtool
+- name: configure lldpd settings to only listen on non-mgmt ports
+  blockinfile:
+    dest: /etc/lldp.d/README.conf
+    insertafter: EOF
+    block: |
+      configure system interface pattern eth*,!eth0
+      configure lldp portidsubtype ifname
+  become: yes
 - service:
     name: lldpd
     enabled: yes
@@ -130,7 +138,7 @@
   become: yes
 - shell: ifdown --force --all --allow=ansible && ifup --force --all --allow=ansible
   become: true
-  
+
 - name: Start NetQ and Connect to the NetQ Telemetry Server
   service:
     name: rsyslog

--- a/roles/switch-common/tasks/main.yaml
+++ b/roles/switch-common/tasks/main.yaml
@@ -24,6 +24,18 @@
   - include: "{{ inventory_dir }}/roles/switch-common/tasks/reboot.yaml"
   when: MGMT_VRF_CHECK.stdout.find('inet 127.0.0.1/8 scope host mgmt') == -1
 
+- name: configure lldpd settings to only listen on non-mgmt ports
+  blockinfile:
+    dest: /etc/lldp.d/README.conf
+    insertafter: EOF
+    block: |
+      configure system interface pattern eth*,swp*,!eth0
+  become: yes
+- service:
+    name: lldpd
+    state: restarted
+  become: true
+
 - name: install netq
   apt_repository:
     repo: deb https://apps3.cumulusnetworks.com/repos/deb CumulusLinux-3 netq-1.1


### PR DESCRIPTION
Adding LLDP modifications to make netq tracing work more intuitively for user. This is because our OOB environment is a hub rather than a switch, so disabling lldp on mgmt/eth0 interface is the best option for the time being.